### PR TITLE
Display: Update framebuffer support to comply with new coreboot addresses and definitions

### DIFF
--- a/Include/Device/MemoryMap.h
+++ b/Include/Device/MemoryMap.h
@@ -93,8 +93,11 @@ static ARM_MEMORY_REGION_DESCRIPTOR_EX gDeviceMemoryDescriptorEx[] =
 	},
 	{
 		// HLOS memory 2
+		// Be aware that we are avoiding carveout regions and fb.
+		// The carveout is configured in Coreboot.
+		// VPR is 0, do not attempt to call hardware codec
 		0x801f0000,
-		0x5f990000,
+		0x75810000,
 		EFI_RESOURCE_SYSTEM_MEMORY,
 		SYSTEM_MEMORY_RESOURCE_ATTR_CAPABILITIES,
 		ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK,
@@ -103,26 +106,13 @@ static ARM_MEMORY_REGION_DESCRIPTOR_EX gDeviceMemoryDescriptorEx[] =
 	},
 	{
 		// Display Reserved
-		0xdfb80000,
-		0x480000,
+		0xf5a00000,
+		0x400000,
 		EFI_RESOURCE_MEMORY_RESERVED, 
 		EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE, 
 		ARM_MEMORY_REGION_ATTRIBUTE_WRITE_THROUGH, 
 		AddMem, 
 		EfiMaxMemoryType
-	},
-	{
-		// HLOS memory 5
-		// Be aware that we are avoiding carveout regions.
-		// The carveout is configured in Coreboot.
-		// VPR has been modified, do not attempt to call hardware codec
-		0xE0000000,
-		0x1E900000,
-		EFI_RESOURCE_SYSTEM_MEMORY,
-		SYSTEM_MEMORY_RESOURCE_ATTR_CAPABILITIES,
-		ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK,
-		AddMem,
-		EfiConventionalMemory
 	},
 	// Carveout
 	{

--- a/NintendoSwitch.dec
+++ b/NintendoSwitch.dec
@@ -34,10 +34,10 @@
 
 [PcdsFixedAtBuild.common]
   # Simple FrameBuffer
-  gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferAddress|0xc0000000|UINT32|0x0000a400
+  gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferAddress|0xf5a00000|UINT32|0x0000a400
   # It's actually vertical.
   # Maybe in the future we can workaround this in EL2
-  gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferWidth|768|UINT32|0x0000a401
+  gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferWidth|720|UINT32|0x0000a401
   gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferHeight|1280|UINT32|0x0000a402
   gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferPixelBpp|32|UINT32|0x0000a403
   gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferVisibleWidth|720|UINT32|0x0000a405

--- a/NintendoSwitch.dsc
+++ b/NintendoSwitch.dsc
@@ -305,13 +305,13 @@
 
   # Display
   # Simple FrameBuffer
-  gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferAddress|0xdfb80000
+  gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferAddress|0xf5a00000
   gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferWidth|720
   gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferHeight|1280
   gNintendoSwitchPkgTokenSpaceGuid.PcdMipiFrameBufferPixelBpp|32
 
   # TrustZone carveout, 14MB below slot 1 top
-  gNintendoSwitchPkgTokenSpaceGuid.PcdTrustZoneCarveoutSize|0xe00000
+  gNintendoSwitchPkgTokenSpaceGuid.PcdTrustZoneCarveoutSize|0
 
   #
   # Make VariableRuntimeDxe work at emulated non-volatile variable mode.


### PR DESCRIPTION
# Changelog
- Fixed framebuffer address
- Fix display width and height
- Removed HLOS memory 5
- Change Carveout size to 0